### PR TITLE
Support inverted value ranges

### DIFF
--- a/Joystick/examples/JoystickTest/JoystickTest.ino
+++ b/Joystick/examples/JoystickTest/JoystickTest.ino
@@ -157,13 +157,13 @@ void testHatSwitch(unsigned int currentStep)
 void testThrottleRudder(unsigned int value)
 {
   Joystick.setThrottle(value);
-  Joystick.setRudder(255 - value);
+  Joystick.setRudder(value);
 }
 
 void testXYZAxisRotation(unsigned int degree)
 {
   Joystick.setRxAxis(degree);
-  Joystick.setRyAxis(360 - degree);
+  Joystick.setRyAxis(degree);
   Joystick.setRzAxis(degree * 2);
 }
 
@@ -174,10 +174,10 @@ void setup() {
   Joystick.setYAxisRange(-127, 127);
   Joystick.setZAxisRange(-127, 127);
   Joystick.setRxAxisRange(0, 360);
-  Joystick.setRyAxisRange(0, 360);
+  Joystick.setRyAxisRange(360, 0);
   Joystick.setRzAxisRange(0, 720);
   Joystick.setThrottleRange(0, 255);
-  Joystick.setRudderRange(0, 255);
+  Joystick.setRudderRange(255, 0);
   
   if (testAutoSendMode)
   {

--- a/Joystick/src/Joystick.cpp
+++ b/Joystick/src/Joystick.cpp
@@ -41,8 +41,6 @@
 #define JOYSTICK_INCLUDE_BRAKE       B00001000
 #define JOYSTICK_INCLUDE_STEERING    B00010000
 
-#define JOYSTICK_VALUE_RANGE_CHECK(value, l, g) if (((value) < min((l), (g))) || ((value) > max((l), (g)))) return
-
 Joystick_::Joystick_(
 	uint8_t hidReportId,
 	uint8_t joystickType,
@@ -521,80 +519,58 @@ void Joystick_::releaseButton(uint8_t button)
 
 void Joystick_::setXAxis(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _xAxisMinimum, _xAxisMaximum);
-	
 	_xAxis = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setYAxis(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _yAxisMinimum, _yAxisMaximum);
-	
 	_yAxis = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setZAxis(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _zAxisMinimum, _zAxisMaximum);
-
 	_zAxis = value;
 	if (_autoSendState) sendState();
 }
 
 void Joystick_::setRxAxis(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _rxAxisMinimum, _rxAxisMaximum);
-
 	_xAxisRotation = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setRyAxis(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _ryAxisMinimum, _ryAxisMaximum);
-
 	_yAxisRotation = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setRzAxis(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _rzAxisMinimum, _rzAxisMaximum);
-
 	_zAxisRotation = value;
 	if (_autoSendState) sendState();
 }
 
 void Joystick_::setRudder(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _rudderMinimum, _rudderMaximum);
-	
 	_rudder = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setThrottle(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _throttleMinimum, _throttleMaximum);
-	
 	_throttle = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setAccelerator(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _acceleratorMinimum, _acceleratorMaximum);
-
 	_accelerator = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setBrake(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _brakeMinimum, _brakeMaximum);
-
 	_brake = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setSteering(int16_t value)
 {
-	JOYSTICK_VALUE_RANGE_CHECK(value, _steeringMinimum, _steeringMaximum);
-
 	_steering = value;
 	if (_autoSendState) sendState();
 }
@@ -612,27 +588,32 @@ int Joystick_::buildAndSet16BitValue(bool includeValue, int16_t value, int16_t v
 	int16_t convertedValue;
 	uint8_t highByte;
 	uint8_t lowByte;
+	int16_t realMinimum = min(valueMinimum, valueMaximum);
+	int16_t realMaximum = max(valueMinimum, valueMaximum);
 
-	if (includeValue == true) {
+	if (includeValue == false) return 0;
 
-		if (valueMinimum > valueMaximum) {
-			// Values go from a larger number to a smaller number (e.g. 1024 to 0)
-			convertedValue = map(valueMinimum - value, valueMaximum, valueMinimum, actualMinimum, actualMaximum);
-		} else {
-			// Values go from a smaller number to a larger number (e.g. 0 to 1024)
-			convertedValue = map(value, valueMinimum, valueMaximum, actualMinimum, actualMaximum);
-		}
-				
-		highByte = (uint8_t)(convertedValue >> 8);
-		lowByte = (uint8_t)(convertedValue & 0x00FF);
-		
-		dataLocation[0] = lowByte;
-		dataLocation[1] = highByte;
-		
-		return 2;
+	if (value < realMinimum) {
+		value = realMinimum;
 	}
+	if (value > realMaximum) {
+		value = realMaximum;
+	}
+
+	if (valueMinimum > valueMaximum) {
+		// Values go from a larger number to a smaller number (e.g. 1024 to 0)
+		value = realMaximum - value + realMinimum;
+	}
+
+	convertedValue = map(value, realMinimum, realMaximum, actualMinimum, actualMaximum);
+
+	highByte = (uint8_t)(convertedValue >> 8);
+	lowByte = (uint8_t)(convertedValue & 0x00FF);
 	
-	return 0;
+	dataLocation[0] = lowByte;
+	dataLocation[1] = highByte;
+	
+	return 2;
 }
 
 int Joystick_::buildAndSetAxisValue(bool includeAxis, int16_t axisValue, int16_t axisMinimum, int16_t axisMaximum, uint8_t dataLocation[]) 

--- a/Joystick/src/Joystick.cpp
+++ b/Joystick/src/Joystick.cpp
@@ -41,6 +41,8 @@
 #define JOYSTICK_INCLUDE_BRAKE       B00001000
 #define JOYSTICK_INCLUDE_STEERING    B00010000
 
+#define JOYSTICK_VALUE_RANGE_CHECK(value, l, g) if (((value) < min((l), (g))) || ((value) > max((l), (g)))) return
+
 Joystick_::Joystick_(
 	uint8_t hidReportId,
 	uint8_t joystickType,
@@ -519,21 +521,21 @@ void Joystick_::releaseButton(uint8_t button)
 
 void Joystick_::setXAxis(int16_t value)
 {
-	if ((value < _xAxisMinimum) || (value > _xAxisMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _xAxisMinimum, _xAxisMaximum);
 	
 	_xAxis = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setYAxis(int16_t value)
 {
-	if ((value < _yAxisMinimum) || (value > _yAxisMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _yAxisMinimum, _yAxisMaximum);
 	
 	_yAxis = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setZAxis(int16_t value)
 {
-	if ((value < _zAxisMinimum) || (value > _zAxisMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _zAxisMinimum, _zAxisMaximum);
 
 	_zAxis = value;
 	if (_autoSendState) sendState();
@@ -541,21 +543,21 @@ void Joystick_::setZAxis(int16_t value)
 
 void Joystick_::setRxAxis(int16_t value)
 {
-	if ((value < _rxAxisMinimum) || (value > _rxAxisMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _rxAxisMinimum, _rxAxisMaximum);
 
 	_xAxisRotation = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setRyAxis(int16_t value)
 {
-	if ((value < _ryAxisMinimum) || (value > _ryAxisMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _ryAxisMinimum, _ryAxisMaximum);
 
 	_yAxisRotation = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setRzAxis(int16_t value)
 {
-	if ((value < _rzAxisMinimum) || (value > _rzAxisMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _rzAxisMinimum, _rzAxisMaximum);
 
 	_zAxisRotation = value;
 	if (_autoSendState) sendState();
@@ -563,35 +565,35 @@ void Joystick_::setRzAxis(int16_t value)
 
 void Joystick_::setRudder(int16_t value)
 {
-	if ((value < _rudderMinimum) || (value > _rudderMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _rudderMinimum, _rudderMaximum);
 	
 	_rudder = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setThrottle(int16_t value)
 {
-	if ((value < _throttleMinimum) || (value > _throttleMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _throttleMinimum, _throttleMaximum);
 	
 	_throttle = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setAccelerator(int16_t value)
 {
-	if ((value < _acceleratorMinimum) || (value > _acceleratorMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _acceleratorMinimum, _acceleratorMaximum);
 
 	_accelerator = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setBrake(int16_t value)
 {
-	if ((value < _brakeMinimum) || (value > _brakeMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _brakeMinimum, _brakeMaximum);
 
 	_brake = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setSteering(int16_t value)
 {
-	if ((value < _steeringMinimum) || (value > _steeringMaximum)) return;
+	JOYSTICK_VALUE_RANGE_CHECK(value, _steeringMinimum, _steeringMaximum);
 
 	_steering = value;
 	if (_autoSendState) sendState();
@@ -612,7 +614,14 @@ int Joystick_::buildAndSet16BitValue(bool includeValue, int16_t value, int16_t v
 	uint8_t lowByte;
 
 	if (includeValue == true) {
-		convertedValue = map(value, valueMinimum, valueMaximum, actualMinimum, actualMaximum);
+
+		if (valueMinimum > valueMaximum) {
+			// Values go from a larger number to a smaller number (e.g. 1024 to 0)
+			convertedValue = map(valueMinimum - value, valueMaximum, valueMinimum, actualMinimum, actualMaximum);
+		} else {
+			// Values go from a smaller number to a larger number (e.g. 0 to 1024)
+			convertedValue = map(value, valueMinimum, valueMaximum, actualMinimum, actualMaximum);
+		}
 				
 		highByte = (uint8_t)(convertedValue >> 8);
 		lowByte = (uint8_t)(convertedValue & 0x00FF);

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Arduino Joystick Library
-#### Version 2.0.1
+#### Version 2.0.2
 This library can be used with Arduino IDE 1.6.6 (or above) to add one or more joysticks (or gamepads) to the list of HID devices an [Arduino Leonardo](https://www.arduino.cc/en/Main/ArduinoBoardLeonardo) or [Arduino Micro](https://www.arduino.cc/en/Main/ArduinoBoardMicro) (or any Arduino clone that is based on the ATmega32u4) can support. This will not work with Arduino IDE 1.6.5 (or below) or with non-32u4 based Arduino devices (e.g. Arduino UNO, Arduino MEGA, etc.).
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ I have tested this library using the following Arduino IDE Versions:
 - 1.6.11
 - 1.6.12
 - 1.6.13
+- 1.8.0
 
 I have tested this library with the following boards:
 
@@ -220,4 +221,4 @@ works with the Arduino Due. I have also been told Version 1.x of the the Arduino
 - [Arduino UNO](https://www.arduino.cc/en/Main/ArduinoBoardUno) - NOT Supported - However, it might work with the [NicoHood/HoodLoader2](https://github.com/NicoHood/HoodLoader2) library, but I have not had a chance to try this out yet.
 - [Arduino MEGA](https://www.arduino.cc/en/Main/ArduinoBoardMega2560) - NOT Supported - However, it might work with the [NicoHood/HoodLoader2](https://github.com/NicoHood/HoodLoader2) library, but I have not had a chance to try this out yet.
 
-(as of 2016-11-25)
+(as of 2016-12-24)


### PR DESCRIPTION
This pull request allows for analog value ranges to be inverted (e.g. 1023 to 0 as well as 0 to 1023). Many thanks to @baritonomarchetto for the idea and helping to test the update.

This is related to issue #25. 