### PR TITLE
Added return value to sendState()

### DIFF
--- a/Joystick/src/Joystick.cpp
+++ b/Joystick/src/Joystick.cpp
@@ -626,7 +626,7 @@ int Joystick_::buildAndSetSimulationValue(bool includeValue, int16_t value, int1
 	return buildAndSet16BitValue(includeValue, value, valueMinimum, valueMaximum, JOYSTICK_SIMULATOR_MINIMUM, JOYSTICK_SIMULATOR_MAXIMUM, dataLocation);
 }
 
-void Joystick_::sendState()
+int Joystick_::sendState()
 {
 	uint8_t data[_hidReportSize];
 	int index = 0;
@@ -674,7 +674,7 @@ void Joystick_::sendState()
 	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_BRAKE, _brake, _brakeMinimum, _brakeMaximum, &(data[index]));
 	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_STEERING, _steering, _steeringMinimum, _steeringMaximum, &(data[index]));
 
-	DynamicHID().SendReport(_hidReportId, data, _hidReportSize);
+	return DynamicHID().SendReport(_hidReportId, data, _hidReportSize);
 }
 
 #endif

--- a/Joystick/src/Joystick.h
+++ b/Joystick/src/Joystick.h
@@ -211,7 +211,7 @@ public:
 
 	void setHatSwitch(int8_t hatSwitch, int16_t value);
 
-	void sendState();
+	int sendState();
 };
 
 #endif // !defined(_USING_DYNAMIC_HID)


### PR DESCRIPTION
The return value can be useful to detect, if USB host is active, or if
it only supply power to the device.

Fixes # or Enhancement #

Changes proposed in this pull request:

- 
- 
- 

Contributors:
