### PR TITLE
Adds support for Adafruit TinyUSB devices

### DIFF
--- a/Joystick/src/Joystick.cpp
+++ b/Joystick/src/Joystick.cpp
@@ -482,7 +482,7 @@ Joystick_::Joystick_(
 void Joystick_::begin(bool initAutoSendState, uint8_t intervalMs)
 {
 #ifdef USE_TINYUSB
-	_usb_hid.setPollInterval(2);
+	_usb_hid.setPollInterval(intervalMs);
   _usb_hid.begin();
 
   while(!USBDevice.mounted()) delay(1);

--- a/Joystick/src/Joystick.cpp
+++ b/Joystick/src/Joystick.cpp
@@ -435,8 +435,12 @@ Joystick_::Joystick_(
 	memcpy(customHidReportDescriptor, tempHidReportDescriptor, hidReportDescriptorSize);
 	
 	// Register HID Report Description
+#ifdef USE_TINYUSB
+	_usb_hid.setReportDescriptor(customHidReportDescriptor, hidReportDescriptorSize);
+#else
 	DynamicHIDSubDescriptor *node = new DynamicHIDSubDescriptor(customHidReportDescriptor, hidReportDescriptorSize, false);
 	DynamicHID().AppendDescriptor(node);
+#endif
 	
     // Setup Joystick State
 	if (buttonCount > 0) {
@@ -475,8 +479,15 @@ Joystick_::Joystick_(
     }
 }
 
-void Joystick_::begin(bool initAutoSendState)
+void Joystick_::begin(bool initAutoSendState, uint8_t intervalMs)
 {
+#ifdef USE_TINYUSB
+	_usb_hid.setPollInterval(2);
+  _usb_hid.begin();
+
+  while(!USBDevice.mounted()) delay(1);
+#endif
+
 	_autoSendState = initAutoSendState;
 	sendState();
 }
@@ -674,7 +685,16 @@ void Joystick_::sendState()
 	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_BRAKE, _brake, _brakeMinimum, _brakeMaximum, &(data[index]));
 	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_STEERING, _steering, _steeringMinimum, _steeringMaximum, &(data[index]));
 
+#ifdef USE_TINYUSB
+	if (_usb_hid.ready()) {
+    _usb_hid.sendReport(_hidReportId, data, _hidReportSize);
+  }
+
+  if (USBDevice.suspended())
+    USBDevice.remoteWakeup();
+#else
 	DynamicHID().SendReport(_hidReportId, data, _hidReportSize);
+#endif
 }
 
 #endif

--- a/Joystick/src/Joystick.h
+++ b/Joystick/src/Joystick.h
@@ -21,7 +21,11 @@
 #ifndef JOYSTICK_h
 #define JOYSTICK_h
 
+#ifdef USE_TINYUSB
+#include <Adafruit_TinyUSB.h>
+#else
 #include <DynamicHID/DynamicHID.h>
+#endif
 
 #if ARDUINO < 10606
 #error The Joystick library requires Arduino IDE 1.6.6 or greater. Please update your IDE.
@@ -107,6 +111,10 @@ private:
 	uint8_t                  _hidReportId;
 	uint8_t                  _hidReportSize; 
 
+#ifdef USE_TINYUSB
+	Adafruit_USBD_HID				 _usb_hid;
+#endif
+
 protected:
 	int buildAndSet16BitValue(bool includeValue, int16_t value, int16_t valueMinimum, int16_t valueMaximum, int16_t actualMinimum, int16_t actualMaximum, uint8_t dataLocation[]);
 	int buildAndSetAxisValue(bool includeAxis, int16_t axisValue, int16_t axisMinimum, int16_t axisMaximum, uint8_t dataLocation[]);
@@ -130,7 +138,7 @@ public:
 		bool includeBrake = true,
 		bool includeSteering = true);
 
-	void begin(bool initAutoSendState = true);
+	void begin(bool initAutoSendState = true, uint8_t interval_ms = 2);
 	void end();
 	
 	// Set Range Functions


### PR DESCRIPTION
Fixes # or Enhancement #

Changes proposed in this pull request:

- Enables this library to work with any device that supports [Adafruit TinyUSB](https://github.com/adafruit/Adafruit_TinyUSB_Arduino)
- Adds an optional parameter to `begin()` for poll interval to initialize TinyUSB

Contributors:
@nsamala