### PR TITLE
Change DynamicHID.h include from <> to "" to allow use outside Arudino libraries directory

### DIFF
--- a/Joystick/src/Joystick.h
+++ b/Joystick/src/Joystick.h
@@ -21,7 +21,7 @@
 #ifndef JOYSTICK_h
 #define JOYSTICK_h
 
-#include <DynamicHID/DynamicHID.h>
+#include "DynamicHID/DynamicHID.h"
 
 #if ARDUINO < 10606
 #error The Joystick library requires Arduino IDE 1.6.6 or greater. Please update your IDE.


### PR DESCRIPTION
Including DynamicHID.h in Joystick.h using <> prevents it from being found if the library is not in the Arduino/libraries directory. This means that it cannot be included as part of a project and significantly increases the difficulty of using it as a git submodule where the library cannot easily be patched. Using "" should not break anything if it is installed to Arduino/libraries.
This PR simply changes the include to "".
