### PR TITLE
Add support for two more axis - slider and dial

### DIFF
--- a/Joystick/src/Joystick.cpp
+++ b/Joystick/src/Joystick.cpp
@@ -34,6 +34,8 @@
 #define JOYSTICK_INCLUDE_RX_AXIS B00001000
 #define JOYSTICK_INCLUDE_RY_AXIS B00010000
 #define JOYSTICK_INCLUDE_RZ_AXIS B00100000
+#define JOYSTICK_INCLUDE_SLIDER_AXIS B01000000
+#define JOYSTICK_INCLUDE_DIAL_AXIS B10000000
 
 #define JOYSTICK_INCLUDE_RUDDER      B00000001
 #define JOYSTICK_INCLUDE_THROTTLE    B00000010
@@ -52,6 +54,8 @@ Joystick_::Joystick_(
 	bool includeRxAxis,
 	bool includeRyAxis,
 	bool includeRzAxis,
+	bool includeSliderAxis,
+	bool includeDialAxis,
 	bool includeRudder,
 	bool includeThrottle,
 	bool includeAccelerator,
@@ -71,6 +75,8 @@ Joystick_::Joystick_(
 	_includeAxisFlags |= (includeRxAxis ? JOYSTICK_INCLUDE_RX_AXIS : 0);
 	_includeAxisFlags |= (includeRyAxis ? JOYSTICK_INCLUDE_RY_AXIS : 0);
 	_includeAxisFlags |= (includeRzAxis ? JOYSTICK_INCLUDE_RZ_AXIS : 0);
+	_includeAxisFlags |= (includeSliderAxis ? JOYSTICK_INCLUDE_SLIDER_AXIS : 0);
+	_includeAxisFlags |= (includeDialAxis ? JOYSTICK_INCLUDE_DIAL_AXIS : 0);
 	_includeSimulatorFlags = 0;
 	_includeSimulatorFlags |= (includeRudder ? JOYSTICK_INCLUDE_RUDDER : 0);
 	_includeSimulatorFlags |= (includeThrottle ? JOYSTICK_INCLUDE_THROTTLE : 0);
@@ -94,7 +100,9 @@ Joystick_::Joystick_(
 		+  (includeZAxis == true)
 		+  (includeRxAxis == true)
 		+  (includeRyAxis == true)
-		+  (includeRzAxis == true);
+		+  (includeRzAxis == true)
+		+  (includeSliderAxis == true)
+		+  (includeDialAxis == true);
 		
 	uint8_t simulationCount = (includeRudder == true)
 		+ (includeThrottle == true)
@@ -351,6 +359,18 @@ Joystick_::Joystick_(
 			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x35;
 		}
 		
+		if (includeSliderAxis == true) {
+			// USAGE (Slider)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x36;
+		}
+		
+		if (includeDialAxis == true) {
+			// USAGE (Dial)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x37;
+		}
+		
 		// INPUT (Data,Var,Abs)
 		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x81;
 		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
@@ -460,6 +480,8 @@ Joystick_::Joystick_(
 	_xAxisRotation = 0;
 	_yAxisRotation = 0;
 	_zAxisRotation = 0;
+	_sliderAxis = 0;
+	_dialAxis = 0;
 	_throttle = 0;
 	_rudder = 0;
 	_accelerator = 0;
@@ -546,6 +568,17 @@ void Joystick_::setRyAxis(int16_t value)
 void Joystick_::setRzAxis(int16_t value)
 {
 	_zAxisRotation = value;
+	if (_autoSendState) sendState();
+}
+
+void Joystick_::setSliderAxis(int16_t value)
+{
+	_sliderAxis = value;
+	if (_autoSendState) sendState();
+}
+void Joystick_::setDialAxis(int16_t value)
+{
+	_dialAxis = value;
 	if (_autoSendState) sendState();
 }
 
@@ -666,7 +699,9 @@ void Joystick_::sendState()
 	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_RX_AXIS, _xAxisRotation, _rxAxisMinimum, _rxAxisMaximum, &(data[index]));
 	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_RY_AXIS, _yAxisRotation, _ryAxisMinimum, _ryAxisMaximum, &(data[index]));
 	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_RZ_AXIS, _zAxisRotation, _rzAxisMinimum, _rzAxisMaximum, &(data[index]));
-	
+	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_SLIDER_AXIS, _sliderAxis, _sliderAxisMinimum, _sliderAxisMaximum, &(data[index]));
+	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_DIAL_AXIS, _dialAxis, _dialAxisMinimum, _dialAxisMaximum, &(data[index]));
+
 	// Set Simulation Values
 	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_RUDDER, _rudder, _rudderMinimum, _rudderMaximum, &(data[index]));
 	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_THROTTLE, _throttle, _throttleMinimum, _throttleMaximum, &(data[index]));

--- a/Joystick/src/Joystick.h
+++ b/Joystick/src/Joystick.h
@@ -66,6 +66,8 @@ private:
 	int16_t	                 _xAxisRotation;
 	int16_t	                 _yAxisRotation;
 	int16_t	                 _zAxisRotation;
+	int16_t	                 _sliderAxis;
+	int16_t	                 _dialAxis;
 	int16_t                  _throttle;
 	int16_t                  _rudder;
 	int16_t					 _accelerator;
@@ -93,6 +95,10 @@ private:
 	int16_t                  _ryAxisMaximum = JOYSTICK_DEFAULT_AXIS_MAXIMUM;
 	int16_t                  _rzAxisMinimum = JOYSTICK_DEFAULT_AXIS_MINIMUM;
 	int16_t                  _rzAxisMaximum = JOYSTICK_DEFAULT_AXIS_MAXIMUM;
+	int16_t                  _sliderAxisMinimum = JOYSTICK_DEFAULT_AXIS_MINIMUM;
+	int16_t                  _sliderAxisMaximum = JOYSTICK_DEFAULT_AXIS_MAXIMUM;
+	int16_t                  _dialAxisMinimum = JOYSTICK_DEFAULT_AXIS_MINIMUM;
+	int16_t                  _dialAxisMaximum = JOYSTICK_DEFAULT_AXIS_MAXIMUM;
 	int16_t                  _rudderMinimum = JOYSTICK_DEFAULT_SIMULATOR_MINIMUM;
 	int16_t                  _rudderMaximum = JOYSTICK_DEFAULT_SIMULATOR_MAXIMUM;
 	int16_t                  _throttleMinimum = JOYSTICK_DEFAULT_SIMULATOR_MINIMUM;
@@ -124,6 +130,8 @@ public:
 		bool includeRxAxis = true,
 		bool includeRyAxis = true,
 		bool includeRzAxis = true,
+		bool includeSliderAxis = true,
+		bool includeDialAxis = true,
 		bool includeRudder = true,
 		bool includeThrottle = true,
 		bool includeAccelerator = true,
@@ -164,6 +172,16 @@ public:
 		_rzAxisMinimum = minimum;
 		_rzAxisMaximum = maximum;
 	}
+	inline void setSliderAxisRange(int16_t minimum, int16_t maximum)
+	{
+		_sliderAxisMinimum = minimum;
+		_sliderAxisMaximum = maximum;
+	}
+	inline void setDialAxisRange(int16_t minimum, int16_t maximum)
+	{
+		_dialAxisMinimum = minimum;
+		_dialAxisMaximum = maximum;
+	}
 	inline void setRudderRange(int16_t minimum, int16_t maximum)
 	{
 		_rudderMinimum = minimum;
@@ -197,6 +215,10 @@ public:
 	void setRxAxis(int16_t value);
 	void setRyAxis(int16_t value);
 	void setRzAxis(int16_t value);
+	
+	// Set Slider Values
+	void setSliderAxis(int16_t value);
+	void setDialAxis(int16_t value);
 
 	// Set Simuation Values
 	void setRudder(int16_t value);


### PR DESCRIPTION
Fixes # or Enhancement #

DirectInput supports up to 8 axis from generic gamepad. There are missing two axis in this library (slider and dial).

[USB HID Table, page 26](https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf)

