### PR TITLE
Updated examples to use LED_BUILTIN instead of 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arduino Joystick Library
 
-#### Version 2.0.6
+#### Version 2.0.7
 
 This library can be used with Arduino IDE 1.6.6 (or above) to add one or more joysticks (or gamepads) to the list of HID devices an [Arduino Leonardo](https://www.arduino.cc/en/Main/ArduinoBoardLeonardo) or [Arduino Micro](https://www.arduino.cc/en/Main/ArduinoBoardMicro) (or any Arduino clone that is based on the ATmega32u4) can support. This library will also work with the [Arduino Due](https://www.arduino.cc/en/Main/ArduinoBoardDue), thanks to [@Palakis](https://github.com/Palakis). A complete list of supported boards can be found in the [Wiki](https://github.com/MHeironimus/ArduinoJoystickLibrary/wiki/Supported-Boards). This will not work with Arduino IDE 1.6.5 (or below) or with non-32u4 based Arduino devices (e.g. Arduino UNO, Arduino MEGA, etc.).
 

--- a/examples/DrivingControllerTest/DrivingControllerTest.ino
+++ b/examples/DrivingControllerTest/DrivingControllerTest.ino
@@ -97,7 +97,7 @@ void setup() {
   }
   
   pinMode(A0, INPUT_PULLUP);
-  pinMode(13, OUTPUT);
+  pinMode(LED_BUILTIN, OUTPUT);
 }
 
 void loop() {
@@ -106,12 +106,12 @@ void loop() {
   if (digitalRead(A0) != 0)
   {
     // Turn indicator light off.
-    digitalWrite(13, 0);
+    digitalWrite(LED_BUILTIN, 0);
     return;
   }
 
   // Turn indicator light on.
-  digitalWrite(13, 1);
+  digitalWrite(LED_BUILTIN, 1);
   
   if (millis() >= gNextTime)
   {

--- a/examples/FlightControllerTest/FlightControllerTest.ino
+++ b/examples/FlightControllerTest/FlightControllerTest.ino
@@ -125,7 +125,7 @@ void setup() {
   }
   
   pinMode(A0, INPUT_PULLUP);
-  pinMode(13, OUTPUT);
+  pinMode(LED_BUILTIN, OUTPUT);
 }
 
 void loop() {
@@ -134,12 +134,12 @@ void loop() {
   if (digitalRead(A0) != 0)
   {
     // Turn indicator light off.
-    digitalWrite(13, 0);
+    digitalWrite(LED_BUILTIN, 0);
     return;
   }
 
   // Turn indicator light on.
-  digitalWrite(13, 1);
+  digitalWrite(LED_BUILTIN, 1);
   
   if (millis() >= gNextTime)
   {

--- a/examples/JoystickTest/JoystickTest.ino
+++ b/examples/JoystickTest/JoystickTest.ino
@@ -189,7 +189,7 @@ void setup() {
   }
   
   pinMode(A0, INPUT_PULLUP);
-  pinMode(13, OUTPUT);
+  pinMode(LED_BUILTIN, OUTPUT);
 }
 
 void loop() {
@@ -198,12 +198,12 @@ void loop() {
   if (digitalRead(A0) != 0)
   {
     // Turn indicator light off.
-    digitalWrite(13, 0);
+    digitalWrite(LED_BUILTIN, 0);
     return;
   }
 
   // Turn indicator light on.
-  digitalWrite(13, 1);
+  digitalWrite(LED_BUILTIN, 1);
   
   if (millis() >= gNextTime)
   {

--- a/examples/MultipleJoystickTest/MultipleJoystickTest.ino
+++ b/examples/MultipleJoystickTest/MultipleJoystickTest.ino
@@ -116,7 +116,7 @@ void setup() {
   }
   
   pinMode(A0, INPUT_PULLUP);
-  pinMode(13, OUTPUT);
+  pinMode(LED_BUILTIN, OUTPUT);
 }
 
 void loop() {
@@ -124,12 +124,12 @@ void loop() {
   // System Disabled
   if (digitalRead(A0) != 0)
   {
-    digitalWrite(13, 0);
+    digitalWrite(LED_BUILTIN, 0);
     return;
   }
 
   // Turn indicator light on.
-  digitalWrite(13, 1);
+  digitalWrite(LED_BUILTIN, 1);
   
   if (millis() >= gNextTime)
   {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Joystick
-version=2.0.6
+version=2.0.7
 author=Matthew Heironimus
 maintainer=Matthew Heironimus <heironimus@live.com>
 sentence=Allows an Arduino board with USB capabilities (e.g. Leonardo, Arduino Micro, Arudino Due, etc.) to appear as a Joystick or Gamepad.


### PR DESCRIPTION
Updated the examples to use LED_BUILTIN instead of a hard-coded pin 13.