### PR TITLE
Fix Arduino version clause in Joystick.h

### DIFF
--- a/src/Joystick.h
+++ b/src/Joystick.h
@@ -27,11 +27,11 @@
 #error The Joystick library requires Arduino IDE 1.6.6 or greater. Please update your IDE.
 #endif // ARDUINO < 10606
 
-#if ARDUINO > 10606
+#if ARDUINO >= 10606
 #if !defined(USBCON)
 #error The Joystick library can only be used with a USB MCU (e.g. Arduino Leonardo, Arduino Micro, etc.).
 #endif // !defined(USBCON)
-#endif // ARDUINO > 10606
+#endif // ARDUINO >= 10606
 
 #if !defined(_USING_DYNAMIC_HID)
 


### PR DESCRIPTION
I just noticed that the case for version = 10606 is not handled, here's a small fix for that :)